### PR TITLE
Allow capturing of non-200 responses

### DIFF
--- a/pmxdr-host.js
+++ b/pmxdr-host.js
@@ -82,7 +82,7 @@ if (this.JSON && (!JSON.stringify || !JSON.parse))
 
       req.onreadystatechange = function() {
         if (this.readyState == 4) {
-          if (this.status == 200) {
+          if (!this.status) {
             function getResponseHeader(header) {
               return req.getResponseHeader(header)
             }


### PR DESCRIPTION
200 is the norm for successful responses, but I am trying to work with a RESTful interface and had to deal with 202, 409, and 500 responses.  I need to get the message body, which usually would be returned by XHttpRequest but is not being returned by pmxdr due to a single line.  This pull request just alters that line so that if there is no status, if it is zero, or if it is an empty string, then send the LOAD_ERROR message as opposed to doing it for non-200 responses.
