### PR TITLE
Fixing caching header to be maximum date allowed on XP

### DIFF
--- a/apache_php/api.php
+++ b/apache_php/api.php
@@ -8,6 +8,6 @@ $version = "0.0.6";
 header("Content-Type: text/html; charset=UTF-8");
 header("ETag: ".$version);
 //Uncomment to cache for almost forever
-//header('Expires: Wed, 31 Dec 9999 00:00:00 GMT');
+//header('Expires: Sat, 31 Dec 2107 23:59:58 GMT');
 
 ?><!doctype html><script type="text/javascript"><?php include('pmxdr-host.js')?></script>


### PR DESCRIPTION
Below is the commit message.  Upon rereading it I realize that I'm too much of a geek at times.

---

It turns out that IE8 on Windows XP (a 32-bit operating system) internally must store dates in the same way that MS-DOS file timestamps are stored.  It uses 16 bits for a date and 16 bits for a time, and it starts the clock at 1980-01-01 00:00:00 (no time zone information) and ends at 2107-12-31 23:59:58.  The seconds may seem odd, but MS-DOS drops the resolution of the seconds down to just even numbers in order to squeeze it into 16 bits.

Here's a bitwise breakdown for more information:

```
FEDC BA98 7654 3210   FEDC BA98 7654 3210
YYYY YYYM MMMD DDDD   HHHH Hmmm mmmS SSSS
```

You will get the possible maximums as:
    Y (year): 127
    M (month): 16
    D (day): 31
    H (hour): 31
    m (minute): 63
    S (seconds / 2): 31

So, because S can only go up to 31, only even numbers of seconds are stored, giving you a granularity down to a 2 second margin.
