### PR TITLE
I had the logic backwards with checking this.status

### DIFF
--- a/pmxdr-host.js
+++ b/pmxdr-host.js
@@ -82,7 +82,7 @@ if (this.JSON && (!JSON.stringify || !JSON.parse))
 
       req.onreadystatechange = function() {
         if (this.readyState == 4) {
-          if (!this.status) {
+          if (this.status) {
             function getResponseHeader(header) {
               return req.getResponseHeader(header)
             }


### PR DESCRIPTION
If the status is truthy (ie. 200, 201, 400, 500, etc), then we want everything possible.  If the status is falsy (undefined, 0, empty string), then something is severely wrong and we can't assume anything is really there or anything is really correct.
